### PR TITLE
API KEY 숨기기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# ignore properties file
+application.properties
+application-API-KEY.properties
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/src/main/java/com/CapStone/Backend/Controller/TestController.java
+++ b/src/main/java/com/CapStone/Backend/Controller/TestController.java
@@ -1,6 +1,7 @@
 package com.CapStone.Backend.Controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 @CrossOrigin
 public class TestController {
 
+    @Value("${GOOGLE-MAP-KEY}")
+    private String Google_Map_Api;
+
     @GetMapping("/test")
     public Boolean testCallback() {
+        System.out.println("google key 값 : " + Google_Map_Api);
         return true;
     }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 server.port=9090
+
+#API KEYS
+spring.profiles.include=API-KEY


### PR DESCRIPTION
### 사용법
(1) ```application-API-KEY```에 추가하고 싶은 API KEY를
```키 이름 = 키값```으로 추가한다.
Ex) ```google-api=12345```

(2) Key를 사용하고 싶은 위치에
```@Value("${키 이름}") private String 변수명;```을 추가하여 사용한다.
- 예시는 TestController 참고

---

감춰야할 정보들(예를 들어, DB Id, 비번 등)은 ```application-API-KEY```처럼 파일을 생성하여 ```application.properties```에 ```spring.profiles.include=파일명```으로 추가할 것

---
>참고 링크 : https://miinsun.tistory.com/224